### PR TITLE
#inner_html is choking on self-closing tags within HTML5 elements

### DIFF
--- a/lib/rack/pjax.rb
+++ b/lib/rack/pjax.rb
@@ -18,10 +18,11 @@ module Rack
           parsed_body = Hpricot(b)
           container = parsed_body.at("[@data-pjax-container]")
           if container
+            children = container.children
             title = parsed_body.at("title")
 
             new_body << title.to_s if title
-            new_body << container.inner_html
+            new_body << children.map { |c| c.to_original_html }.join
           else
             new_body << b
           end

--- a/spec/rack/pjax_spec.rb
+++ b/spec/rack/pjax_spec.rb
@@ -10,8 +10,8 @@ describe Rack::Pjax do
       Rack::Pjax.new(
         lambda do |env|
           [
-            200, 
-            {'Content-Type' => 'text/plain', 'Content-Length' => Rack::Utils.bytesize(body).to_s}, 
+            200,
+            {'Content-Type' => 'text/plain', 'Content-Length' => Rack::Utils.bytesize(body).to_s},
             [body]
           ]
         end
@@ -34,6 +34,14 @@ describe Rack::Pjax do
 
       get "/", {}, {"HTTP_X_PJAX" => "true"}
       body.should == "World!"
+    end
+
+    it "should handle self closing tags with HTML5 elements" do
+      self.class.app = generate_app(:body => '<html><body><div data-pjax-container><article>World!<img src="test.jpg" /></article></div></body></html>')
+
+      get "/", {}, {"HTTP_X_PJAX" => "true"}
+
+      body.should == '<article>World!<img src="test.jpg" /></article>'
     end
 
     it "should return the correct Content Length" do


### PR DESCRIPTION
See https://github.com/hpricot/hpricot/issues/48

Re: https://github.com/eval/rack-pjax/blob/master/lib/rack/pjax.rb#L24

It appears Hpricot has some issues with HTML5 tags. This can be avoided by using `to_original_html` instead of `inner_html`.

Unfortunately, unlike `inner_html`, `to_original_html` returns the container element as well as the html inside of it so we can't use it directly and instead must iterate over the children.

I've attached a pull request (with passing spec) for your perusal.
