### PR TITLE
Enable multiple pjax containers

### DIFF
--- a/lib/rack/pjax.rb
+++ b/lib/rack/pjax.rb
@@ -14,7 +14,7 @@ module Rack
 
       if pjax?(env)
         params = Request.new(env).params
-        pjax_container = params['_pjax_return'] || '[data-pjax-container]'
+        pjax_container = params['_pjax_return'] || 'data-pjax-container'
         
         new_body = ""
         body.each do |b|


### PR DESCRIPTION
I have two pjax containers on the site and I wanted a way to specify which container to return when transitioning from the login page to the application. When logged in, I receive a header as well as some content but each additional time I don't want to receive the header on each request.
