### PR TITLE
Fixed urls on redirects

### DIFF
--- a/lib/rack/pjax.rb
+++ b/lib/rack/pjax.rb
@@ -32,6 +32,7 @@ module Rack
         body = [new_body]
 
         headers['Content-Length'] &&= bytesize(new_body).to_s
+        headers['X-PJAX-URL'] = env['REQUEST_URI'] if env['REQUEST_URI']
       end
       [status, headers, body]
     end


### PR DESCRIPTION
If the server redirects to another url, we can't check it by xhr request,
but in pjax_rails, they solved this problem by adding X-AJAX-URL to the response headers.

See:
https://github.com/rails/pjax_rails/blob/master/vendor/assets/javascripts/jquery.pjax.js#L200
https://github.com/rails/pjax_rails/blob/master/lib/pjax.rb#L31
