### PR TITLE
Allow to specify container in the X-PJAX-CONTAINER header

### DIFF
--- a/lib/rack/pjax.rb
+++ b/lib/rack/pjax.rb
@@ -16,7 +16,7 @@ module Rack
         new_body = ""
         body.each do |b|
           parsed_body = Hpricot.XML(b)
-          container = parsed_body.at("[@data-pjax-container]")
+          container = parsed_body.at(container_selector(env))
           if container
             children = container.children
             title = parsed_body.at("title")
@@ -40,6 +40,10 @@ module Rack
     protected
       def pjax?(env)
         env['HTTP_X_PJAX']
+      end
+
+      def container_selector(env)
+        env['HTTP_X_PJAX_CONTAINER'] || "[@data-pjax-container]"
       end
   end
 end

--- a/spec/rack/pjax_spec.rb
+++ b/spec/rack/pjax_spec.rb
@@ -36,6 +36,13 @@ describe Rack::Pjax do
       body.should == "World!"
     end
 
+    it "should return the inner-html of the custom pjax-container in the body" do
+      self.class.app = generate_app(:body => '<html><body><div id="container">World!</div></body></html>')
+
+      get "/", {}, {"HTTP_X_PJAX" => "true", "HTTP_X_PJAX_CONTAINER" => "#container"}
+      body.should == "World!"
+    end
+
     it "should handle self closing tags with HTML5 elements" do
       self.class.app = generate_app(:body => '<html><body><div data-pjax-container><article>World!<img src="test.jpg" /></article></div></body></html>')
 


### PR DESCRIPTION
It will work for [my fork of jquery-pjax](https://github.com/DarthSim/jquery-pjax) or when [this pull request](https://github.com/defunkt/jquery-pjax/pull/99) will be submited.
