### PR TITLE
changed html parser to nokogiri for better html5 support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source "http://rubygems.org"
 
 gem 'rake'
+gem 'nokogiri', '~>1.5.2'
 
 gemspec
 

--- a/lib/rack/pjax.rb
+++ b/lib/rack/pjax.rb
@@ -1,4 +1,4 @@
-require 'hpricot'
+require 'nokogiri'
 
 module Rack
   class Pjax
@@ -15,7 +15,7 @@ module Rack
       if pjax?(env)
         new_body = ""
         body.each do |b|
-          parsed_body = Hpricot.XML(b)
+          parsed_body = Nokogiri::HTML(b)
           container = parsed_body.at("[@data-pjax-container]")
           if container
             title = parsed_body.at("title")

--- a/rack-pjax.gemspec
+++ b/rack-pjax.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency('rack', '~>1.3')
-  s.add_dependency('hpricot', '~>0.8.6')
+  s.add_dependency('nokogiri', '~>1.5.2')
 end

--- a/spec/rack/pjax_spec.rb
+++ b/spec/rack/pjax_spec.rb
@@ -41,7 +41,7 @@ describe Rack::Pjax do
 
       get "/", {}, {"HTTP_X_PJAX" => "true"}
 
-      body.should == '<article>World!<img src="test.jpg" /></article>'
+      body.should == '<article>World!<img src="test.jpg"></article>'
     end
 
     it "should handle nesting of elements inside anchor tags" do
@@ -50,6 +50,14 @@ describe Rack::Pjax do
       get "/", {}, {"HTTP_X_PJAX" => "true"}
 
       body.should == '<a href="#"><h1>World!</h1></a>'
+    end
+
+    it "should handle html5 br tags correctly" do
+      self.class.app = generate_app(:body => '<html><body><div data-pjax-container><p>foo<br>bar</p></div></body></html>')
+
+      get "/", {}, {"HTTP_X_PJAX" => "true"}
+
+      body.should == '<p>foo<br>bar</p>'
     end
 
     it "should return the correct Content Length" do


### PR DESCRIPTION
As far as I understand the "/" in self-closing tags like <img> and <br> isn't neccessary in html5. and because the <br> caused some serious trouble, i decided to replace hpricot by nokogiri which seems to have better html support.

btw. this is my first pull request. so is all i did formally correct?
