### PR TITLE
Parses the X-PJAX-Container header value if it is availabe

### DIFF
--- a/lib/rack/pjax.rb
+++ b/lib/rack/pjax.rb
@@ -11,12 +11,12 @@ module Rack
     def call(env)
       status, headers, body = @app.call(env)
       headers = HeaderHash.new(headers)
-
       if pjax?(env)
+        container_select = env["HTTP_X_PJAX_CONTAINER"] || "[@data-pjax-container]"
         new_body = ""
         body.each do |b|
           parsed_body = Hpricot.XML(b)
-          container = parsed_body.at("[@data-pjax-container]")
+          container = parsed_body.at(container_select)
           if container
             title = parsed_body.at("title")
 


### PR DESCRIPTION
Pjax sends a container id if it has one using the X-PJAX-Container
header value. This enables rack-pjax to parse that value and use it for
the container.

This way different containers can be used for different requests by the
same page.

This pull-request also addresses the issues raised in #12.
