### PR TITLE
Script fragment for passing json data to page

### DIFF
--- a/lib/rack/pjax.rb
+++ b/lib/rack/pjax.rb
@@ -24,8 +24,8 @@ module Rack
         new_body << begin
           if container
             title = parsed_body.at("title")
-
-            "%s%s" % [title, container.inner_html]
+            data = parsed_body.css(data_selector(env))
+            "%s%s%s" % [title, container.inner_html, data]
           else
             b
           end
@@ -47,6 +47,10 @@ module Rack
 
       def container_selector(env)
         env['HTTP_X_PJAX_CONTAINER'] || "[@data-pjax-container]"
+      end
+
+      def data_selector(env)
+        env['HTTP_X_PJAX_DATA'] || "[@data-pjax-data]"
       end
   end
 end

--- a/spec/rack/pjax_spec.rb
+++ b/spec/rack/pjax_spec.rb
@@ -29,7 +29,14 @@ describe Rack::Pjax do
       body.should == "<title>Hello</title>World!"
     end
 
-    it "should return the inner-html of the pjax-container in the body" do
+    it "should return the pjax data script tag" do
+      self.class.app = generate_app(:body => '<html><body><script data-pjax-data>console.log("Hello")</script><div data-pjax-container>World</div><script data-pjax-data>console.log("!")</script></body></html>')
+
+      get "/", {}, {"HTTP_X_PJAX" => "true"}
+      body.should =='World<script data-pjax-data>console.log("Hello")</script><script data-pjax-data>console.log("!")</script>'
+    end
+
+    it "should return the pjax data script tage" do
       self.class.app = generate_app(:body => '<html><body><div data-pjax-container>World!</div></body></html>')
 
       get "/", {}, {"HTTP_X_PJAX" => "true"}
@@ -106,5 +113,6 @@ BODY
       get "/"
       headers['Content-Length'].should == Rack::Utils.bytesize(body).to_s
     end
+
   end
 end


### PR DESCRIPTION
What do you think to this?

Added ability to include `<script data-pjax-data>` anywhere in the response and have it appended to the pjax response

You can put code to be executed in there, but the main idea was to be able to pass data to the page that the pjax:end event can use