### PR TITLE
Do not overwrite X-PJAX-URL

### DIFF
--- a/lib/rack/pjax.rb
+++ b/lib/rack/pjax.rb
@@ -35,7 +35,7 @@ module Rack
       body.close if body.respond_to?(:close)
 
       headers['Content-Length'] &&= bytesize(new_body).to_s
-      headers['X-PJAX-URL'] = Rack::Request.new(env).fullpath
+      headers['X-PJAX-URL'] ||= Rack::Request.new(env).fullpath
 
       [status, headers, [new_body]]
     end


### PR DESCRIPTION
Rack::PJAX overwrite the 'X-PJAX-URL' already set.
