### PR TITLE
Broaden dependencies to make them compatible with rails 5 beta

### DIFF
--- a/rack-pjax.gemspec
+++ b/rack-pjax.gemspec
@@ -18,10 +18,10 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency('rack', '~> 1.1')
+  s.add_dependency('rack', '>= 1.1')
   if RUBY_VERSION < "1.9.2"
     s.add_dependency('nokogiri', '~> 1.5', '< 1.5.11')
   else
-    s.add_dependency('nokogiri', '~> 1.5')
+    s.add_dependency('nokogiri', '>= 1.5')
   end
 end


### PR DESCRIPTION
The specs pass for me when running against rack 1.6.4 and nokogiri 1.6.7.1.