### PR TITLE
Rack 2.0 no longer includes a bytesize method, but luckily strings provide one.

### DIFF
--- a/lib/rack/pjax.rb
+++ b/lib/rack/pjax.rb
@@ -34,7 +34,7 @@ module Rack
 
       body.close if body.respond_to?(:close)
 
-      headers['Content-Length'] &&= bytesize(new_body).to_s
+      headers['Content-Length'] &&= new_body.bytesize.to_s
       headers['X-PJAX-URL'] ||= Rack::Request.new(env).fullpath
 
       [status, headers, [new_body]]

--- a/spec/rack/pjax_spec.rb
+++ b/spec/rack/pjax_spec.rb
@@ -11,7 +11,7 @@ describe Rack::Pjax do
         lambda do |env|
           [
             200,
-            {'Content-Type' => 'text/plain', 'Content-Length' => Rack::Utils.bytesize(body).to_s},
+            {'Content-Type' => 'text/plain', 'Content-Length' => body.bytesize.to_s},
             [body]
           ]
         end
@@ -69,7 +69,7 @@ describe Rack::Pjax do
 
     it "should return the correct Content Length" do
       get "/", {}, {"HTTP_X_PJAX" => "true"}
-      expect(headers['Content-Length']).to eq(Rack::Utils.bytesize(body).to_s)
+      expect(headers['Content-Length']).to eq(body.bytesize.to_s)
     end
 
     it "should return the original body when there's no pjax-container" do
@@ -104,7 +104,7 @@ BODY
 
     it "should return the correct Content Length" do
       get "/"
-      expect(headers['Content-Length']).to eq(Rack::Utils.bytesize(body).to_s)
+      expect(headers['Content-Length']).to eq(body.bytesize.to_s)
     end
   end
 end


### PR DESCRIPTION
Rack::Utils#bytesize was removed in rack/rack@7b5820f.

This should continue to work with older versions of Rack.