### PR TITLE
Add license to gemspec

### DIFF
--- a/rack-pjax.gemspec
+++ b/rack-pjax.gemspec
@@ -8,6 +8,7 @@ Gem::Specification.new do |s|
   s.authors     = ["Gert Goet"]
   s.email       = ["gert@thinkcreate.nl"]
   s.homepage    = "https://github.com/eval/rack-pjax"
+  s.license     = "MIT"
   s.summary     = %q{Serve pjax responses through rack middleware}
   s.description = %q{Serve pjax responses through rack middleware}
 


### PR DESCRIPTION
This PR adds license item to gemspec. This item is used as follows.

- Describing LICENSES on rubygems.org (https://rubygems.org/gems/rack-pjax)
- List of licenses displayed by `bundle licenses` command

This will increase the opportunity for users to learn about license.
