### PR TITLE
Handle frozen body string

### DIFF
--- a/lib/rack/pjax.rb
+++ b/lib/rack/pjax.rb
@@ -16,7 +16,7 @@ module Rack
 
       new_body = ""
       body.each do |b|
-        b.force_encoding('UTF-8') if RUBY_VERSION > '1.9.0'
+        b = b.dup.force_encoding('UTF-8') if RUBY_VERSION > '1.9.0'
 
         parsed_body = Nokogiri::HTML(b)
         container = parsed_body.at(container_selector(env))

--- a/spec/rack/pjax_spec.rb
+++ b/spec/rack/pjax_spec.rb
@@ -67,6 +67,14 @@ describe Rack::Pjax do
       expect(body).to eq('<p>foo<br>bar</p>')
     end
 
+    it "should handle frozen body string correctly" do
+      self.class.app = generate_app(:body => '<html><body><div data-pjax-container><p>foo<br>bar</p></div></body></html>'.freeze)
+
+      get "/", {}, {"HTTP_X_PJAX" => "true"}
+
+      expect(body).to eq('<p>foo<br>bar</p>')
+    end
+
     it "should return the correct Content Length" do
       get "/", {}, {"HTTP_X_PJAX" => "true"}
       expect(headers['Content-Length']).to eq(body.bytesize.to_s)


### PR DESCRIPTION
Hello, 

We have been getting the following error in our application, and this might be the fix for it. 

```
/app/vendor/bundle/ruby/2.5.0/gems/rack-pjax-1.0.0/lib/rack/pjax.rb line 19 in force_encoding
File /app/vendor/bundle/ruby/2.5.0/gems/rack-pjax-1.0.0/lib/rack/pjax.rb line 19 in block in call
File /app/vendor/bundle/ruby/2.5.0/gems/actionpack-5.2.2/lib/action_dispatch/http/response.rb line 147 in each
File /app/vendor/bundle/ruby/2.5.0/gems/actionpack-5.2.2/lib/action_dispatch/http/response.rb line 147 in each_chunk
File /app/vendor/bundle/ruby/2.5.0/gems/actionpack-5.2.2/lib/action_dispatch/http/response.rb line 128 in each
File /app/vendor/bundle/ruby/2.5.0/gems/actionpack-5.2.2/lib/action_dispatch/http/response.rb line 76 in each
File /app/vendor/bundle/ruby/2.5.0/gems/actionpack-5.2.2/lib/action_dispatch/http/response.rb line 475 in each
```